### PR TITLE
Add principal types to the search filter in the Users app #5283

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,6 @@ module.exports = {
         'comma-dangle': ['error', 'never'],
         'no-underscore-dangle': ['off'],
         'func-names': ['off'],
-        'max-len': ['error', 120],
         'no-plusplus': ['error', { 'allowForLoopAfterthoughts': true }],
         'vars-on-top': 'off',
         'global-require': 'off',

--- a/src/main/js/api/graphql/aggregation/UserItemAggregationHelper.ts
+++ b/src/main/js/api/graphql/aggregation/UserItemAggregationHelper.ts
@@ -1,0 +1,28 @@
+import BucketAggregation = api.aggregation.BucketAggregation;
+import {UserItemBucketAggregationJson} from './UserItemBucketAggregationJson';
+import BucketJson = api.aggregation.BucketJson;
+import Bucket = api.aggregation.Bucket;
+import StringHelper = api.util.StringHelper;
+
+export class UserItemAggregationHelper {
+
+    static fromJson(json: UserItemBucketAggregationJson): BucketAggregation {
+        const agg = new BucketAggregation(json.name);
+        json.buckets.forEach((bucketJson: BucketJson) => agg.addBucket(new Bucket(bucketJson.key, bucketJson.docCount)));
+        return agg;
+    }
+
+    static updatePrincipalTypeAggregation(aggregation: BucketAggregation, total: number) {
+        if (aggregation) {
+            const typeAggBuckets = aggregation.getBuckets();
+
+            const principalsCount = typeAggBuckets.length > 1 ?
+                                    typeAggBuckets.reduce((prev: number, curr: Bucket) => prev + curr.getDocCount(), 0) :
+                                    (typeAggBuckets[0] && typeAggBuckets[0].getDocCount() || 0);
+            const userStoresDocCount = total - principalsCount;
+
+            typeAggBuckets.forEach(bucket => bucket.setKey(StringHelper.capitalize(bucket.getKey())));
+            aggregation.addBucket(new Bucket('User Store', userStoresDocCount));
+        }
+    }
+}

--- a/src/main/js/api/graphql/aggregation/UserItemBucketAggregationJson.ts
+++ b/src/main/js/api/graphql/aggregation/UserItemBucketAggregationJson.ts
@@ -1,0 +1,7 @@
+import BucketAggregation = api.aggregation.BucketAggregation;
+import BucketJson = api.aggregation.BucketJson;
+
+export interface UserItemBucketAggregationJson {
+    name: string;
+    buckets: BucketJson[];
+}

--- a/src/main/js/app/browse/UserItemType.ts
+++ b/src/main/js/app/browse/UserItemType.ts
@@ -1,0 +1,8 @@
+import '../../api.ts';
+
+export enum UserItemType {
+    USER,
+    GROUP,
+    ROLE,
+    USER_STORE
+}

--- a/src/main/js/app/browse/filter/PrincipalBrowseFilterPanel.ts
+++ b/src/main/js/app/browse/filter/PrincipalBrowseFilterPanel.ts
@@ -26,15 +26,14 @@ export class PrincipalBrowseFilterPanel
     extends api.app.browse.filter.BrowseFilterPanel<UserTreeGridItem> {
 
     static PRINCIPAL_TYPE_AGGREGATION_NAME: string = 'principalType';
-    static PRINCIPAL_TYPE_AGGREGATION_DISPLAY_NAME: string = i18n('field.principalTypes');
+    static PRINCIPAL_TYPE_AGGREGATION_DISPLAY_NAME: string = i18n('field.types');
 
     private principalTypeAggregation: PrincipalTypeAggregationGroupView;
 
     constructor() {
         super();
 
-        this.initAggregationGroupView([this.principalTypeAggregation]);
-        this.initHitsCounter();
+        this.initHitsCounter().then(() => this.initAggregationGroupView([this.principalTypeAggregation]));
     }
 
     protected getGroupViews(): api.aggregation.AggregationGroupView[] {
@@ -100,9 +99,9 @@ export class PrincipalBrowseFilterPanel
             .filter(type => type != null);
     }
 
-    private searchDataAndHandleResponse(searchString: string, fireEvent: boolean = true) {
+    private searchDataAndHandleResponse(searchString: string, fireEvent: boolean = true): wemQ.Promise<void> {
 
-        new ListUserItemsRequest()
+        return new ListUserItemsRequest()
             .setTypes(this.getCheckedTypes())
             .setQuery(searchString)
             .sendAndParse()
@@ -121,12 +120,12 @@ export class PrincipalBrowseFilterPanel
                 this.updateHitsCounter(userItems ? userItems.length : 0, api.util.StringHelper.isBlank(searchString));
                 this.toggleAggregationsVisibility(result.aggregations);
             }).catch((reason: any) => {
-            api.DefaultErrorHandler.handle(reason);
-        }).done();
+                api.DefaultErrorHandler.handle(reason);
+            });
     }
 
-    private initHitsCounter() {
-        this.searchDataAndHandleResponse('', false);
+    private initHitsCounter(): wemQ.Promise<void> {
+        return this.searchDataAndHandleResponse('', false);
     }
 
     private toggleAggregationsVisibility(aggregations: Aggregation[]) {

--- a/src/main/js/app/browse/filter/PrincipalTypeAggregationGroupView.ts
+++ b/src/main/js/app/browse/filter/PrincipalTypeAggregationGroupView.ts
@@ -1,6 +1,8 @@
 import '../../../api.ts';
-import {ListTypesRequest, TypeAggregation} from '../../../api/graphql/principal/ListTypesRequest';
+import {ListTypesRequest} from '../../../api/graphql/principal/ListTypesRequest';
 import AggregationGroupView = api.aggregation.AggregationGroupView;
+import BucketAggregation = api.aggregation.BucketAggregation;
+import Bucket = api.aggregation.Bucket;
 
 export class PrincipalTypeAggregationGroupView extends AggregationGroupView {
 
@@ -13,9 +15,9 @@ export class PrincipalTypeAggregationGroupView extends AggregationGroupView {
         this.onRendered(() => mask.show());
 
         const request = new ListTypesRequest();
-        request.sendAndParse().done((data: TypeAggregation[]) => {
-            data.forEach((value: TypeAggregation) => {
-                displayNameMap[value.type] = value.type;
+        request.sendAndParse().done((data: BucketAggregation) => {
+            data.getBuckets().forEach((bucket: Bucket) => {
+                displayNameMap[bucket.getKey().replace(/\s/g, '_').toUpperCase()] = bucket.getKey();
             });
 
             this.getAggregationViews().forEach((aggregationView: api.aggregation.AggregationView) => {

--- a/src/main/js/app/browse/filter/PrincipalTypeAggregationGroupView.ts
+++ b/src/main/js/app/browse/filter/PrincipalTypeAggregationGroupView.ts
@@ -3,6 +3,8 @@ import {ListTypesRequest} from '../../../api/graphql/principal/ListTypesRequest'
 import AggregationGroupView = api.aggregation.AggregationGroupView;
 import BucketAggregation = api.aggregation.BucketAggregation;
 import Bucket = api.aggregation.Bucket;
+import i18n = api.util.i18n;
+import StringHelper = api.util.StringHelper;
 
 export class PrincipalTypeAggregationGroupView extends AggregationGroupView {
 
@@ -17,7 +19,8 @@ export class PrincipalTypeAggregationGroupView extends AggregationGroupView {
         const request = new ListTypesRequest();
         request.sendAndParse().done((data: BucketAggregation) => {
             data.getBuckets().forEach((bucket: Bucket) => {
-                displayNameMap[bucket.getKey().replace(/\s/g, '_').toUpperCase()] = bucket.getKey();
+                const key = bucket.getKey().toLowerCase();
+                displayNameMap[key] = this.getTypeName(key);
             });
 
             this.getAggregationViews().forEach((aggregationView: api.aggregation.AggregationView) => {
@@ -26,5 +29,15 @@ export class PrincipalTypeAggregationGroupView extends AggregationGroupView {
 
             mask.remove();
         });
+    }
+
+    private getTypeName(name: string): string {
+        switch (name) {
+        case 'user': return i18n('field.user');
+        case 'group': return i18n('field.group');
+        case 'role': return i18n('field.role');
+        case 'user store': return i18n('field.userStore');
+        default: StringHelper.capitalize(name);
+        }
     }
 }

--- a/src/main/resources/admin/i18n/phrases.properties
+++ b/src/main/resources/admin/i18n/phrases.properties
@@ -30,7 +30,7 @@ field.permissions = Permissions
 field.email = Email
 field.password = Password
 field.authentication = Authentication
-field.principalTypes = Principal Types
+field.types = Types
 
 #
 # Notify

--- a/src/main/resources/admin/i18n/phrases_no.properties
+++ b/src/main/resources/admin/i18n/phrases_no.properties
@@ -30,7 +30,7 @@ field.permissions = Rettigheter
 field.email = Epost
 field.password = Passord
 field.authentication = Autentisering
-field.principalTypes = Principal Typer
+field.types = Typer
 
 #
 # Notify

--- a/src/main/resources/lib/common.js
+++ b/src/main/resources/lib/common.js
@@ -5,6 +5,22 @@ var REPO_NAME = 'system-repo';
 var REPO_BRANCH = 'master';
 var MAX_COUNT = 100;
 
+exports.UserItemType = {
+    ROLE: 'ROLE',
+    USER: 'USER',
+    GROUP: 'GROUP',
+    USER_STORE: 'USER_STORE'
+};
+var UserItemType = exports.UserItemType;
+exports.UserItemType.all = function() {
+    return [
+        UserItemType.ROLE,
+        UserItemType.USER,
+        UserItemType.GROUP,
+        UserItemType.USER_STORE
+    ];
+};
+
 exports.PrincipalType = {
     ROLE: 'ROLE',
     USER: 'USER',

--- a/src/main/resources/site/services/graphql/schema/query.js
+++ b/src/main/resources/site/services/graphql/schema/query.js
@@ -76,15 +76,17 @@ module.exports = graphQl.createObjectType({
         userItemsConnection: {
             type: graphQlObjectTypes.UserItemConnectionType,
             args: {
+                types: graphQl.list(graphQlEnums.UserItemTypeEnum),
                 query: graphQl.GraphQLString,
                 start: graphQl.GraphQLInt,
                 count: graphQl.GraphQLInt
             },
             resolve: function(env) {
+                var types = env.args.types;
                 var query = env.args.query;
                 var count = env.args.count || Number.MAX_SAFE_INTEGER;
                 var start = env.args.start || 0;
-                return useritems.list(query, start, count);
+                return useritems.list(types, query, start, count);
             }
         },
         types: {

--- a/src/main/resources/site/services/graphql/types/enums.js
+++ b/src/main/resources/site/services/graphql/types/enums.js
@@ -19,6 +19,17 @@ exports.SortModeEnum = graphQl.createEnumType({
     }
 });
 
+exports.UserItemTypeEnum = graphQl.createEnumType({
+    name: 'UserItemType',
+    description: 'Enumeration of user item types',
+    values: {
+        USER_STORE: 'USER_STORE',
+        USER: 'USER',
+        GROUP: 'GROUP',
+        ROLE: 'ROLE'
+    }
+});
+
 exports.PrincipalTypeEnum = graphQl.createEnumType({
     name: 'PrincipalType',
     description: 'Enumeration of principal types',

--- a/src/main/resources/site/services/graphql/types/objects/aggregations.js
+++ b/src/main/resources/site/services/graphql/types/objects/aggregations.js
@@ -10,7 +10,7 @@ var BucketType = graphQl.createObjectType({
                 return env.source.key;
             }
         },
-        count: {
+        docCount: {
             type: graphQl.GraphQLInt,
             resolve: function(env) {
                 return env.source.docCount;
@@ -29,7 +29,7 @@ var AggregationType = graphQl.createObjectType({
                 return env.source.name;
             }
         },
-        aggregation: {
+        buckets: {
             type: graphQl.list(BucketType),
             resolve: function(env) {
                 return env.source.aggregation;


### PR DESCRIPTION
Fixed the name of the types aggregation.
Moved shared code to appropriate helper.
Added search by aggregations (`principalType`) from filter panel.

_Part of [XP #5283](https://github.com/enonic/xp/issues/5283)._