### PR TITLE
UserStore wizard - error in console when saving new store #76

### DIFF
--- a/src/main/resources/assets/js/api/graphql/userStore/SaveUserStoreRequest.ts
+++ b/src/main/resources/assets/js/api/graphql/userStore/SaveUserStoreRequest.ts
@@ -93,16 +93,16 @@ export class SaveUserStoreRequest
     }
 
     sendAndParse(): wemQ.Promise<UserStore> {
-        return this.mutate().then(json => this.userStorefromJson(json.updateUserStore, json.error));
+        return this.mutate().then(json => this.userStorefromJson(json[this.mutationType], json.error));
     }
 
     userStorefromJson(us: UserStoreJson, error: string) {
         if (error) {
             throw new Error(error);
+        } else if (!us) {
+            throw new Error(`UserStore [${this.userStoreKey.toString()}] not found`);
         }
-        if (!us) {
-            throw new Error(`UserStore[${this.userStoreKey.toString()}] not found`);
-        }
+
         if (us.authConfig && typeof us.authConfig.config === 'string') {
             us.authConfig.config = JSON.parse(<string>us.authConfig.config);
         }


### PR DESCRIPTION
Fixed the invalid field name that is passed to `userStorefromJson` function in the parent class, that is used both by `UpdateUserStoreRequest` and `CreateUserStoreRequest`.