### PR TITLE
Update publish configuration #132

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'maven'
-    id 'com.enonic.defaults' version '1.0.3'
+    id 'maven-publish'
+    id 'com.enonic.defaults' version '1.1.0'
     id 'com.enonic.xp.app' version '1.1.0'
     id "com.moowork.node" version '1.1.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'maven-publish'
-    id 'com.enonic.defaults' version '1.1.0'
+    id 'com.enonic.defaults' version '2.0.0'
     id 'com.enonic.xp.app' version '1.1.0'
     id "com.moowork.node" version '1.1.1'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,5 @@
 version=7.0.0-SNAPSHOT
 xpVersion=7.0.0-SNAPSHOT
 libAdminUiVersion=1.4.0-SNAPSHOT
+systemProp.org.gradle.internal.http.connectionTimeout=120000
+systemProp.org.gradle.internal.http.socketTimeout=120000

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,5 @@
+enableFeaturePreview('STABLE_PUBLISHING')
+
 if ( hasProperty( 'env' ) ) {
     addBuild('../xp')
     addBuild('../lib-admin-ui')


### PR DESCRIPTION
Update publish configuration to use new version of `app-defaults`, `maven-publish` plugin and `publish` command, instead of maven and `uploadArchives`.
Fixed TIMEOUT exception, when resolving dependencies.

*IMPORTANT:* PR should be merged, when [gradle-defaults v1.1.0](https://github.com/enonic/gradle-defaults/issues/1). is published.