### PR TITLE
Keyboard Shortcuts do not work in Id Provider Wizard #243

### DIFF
--- a/src/main/resources/assets/js/main.ts
+++ b/src/main/resources/assets/js/main.ts
@@ -51,6 +51,8 @@ function startApplication() {
     const application: api.app.Application = getApplication();
     const appBar = new api.app.bar.TabbedAppBar(application);
     appBar.setHomeIconAction();
+
+    const newPrincipalDialog = new NewPrincipalDialog();
     const appPanel = new UserAppPanel(appBar, application.getPath());
 
     body.appendChild(appBar);
@@ -69,7 +71,6 @@ function startApplication() {
 
     PrincipalServerEventsHandler.getInstance().start();
 
-    const newPrincipalDialog = new NewPrincipalDialog();
     ShowNewPrincipalDialogEvent.on((event) => {
         newPrincipalDialog.setSelection(event.getSelection()).open();
     });


### PR DESCRIPTION
-Issue origin: both UserAppPanel and NewPrincipalDialog listen for NewPrincipalEvent, however dialog's listener is invoked after panel's one, and dialog is being closed on that event AFTER new principal panel is open, thus modal dialog shelves/unshelves wrong key bindings after panel with it's own key bindings is open and combination mod+del is not working
-Solved: initializing dialog before UserAppPanel, so dialog's listener is invoked first