### PR TITLE
Sort new leaf nodes by display name in alphabetical order #258

### DIFF
--- a/src/main/resources/assets/js/app/browse/UserBrowsePanel.ts
+++ b/src/main/resources/assets/js/app/browse/UserBrowsePanel.ts
@@ -6,14 +6,14 @@ import {UserTreeGridActions} from './UserTreeGridActions';
 import {PrincipalBrowseFilterPanel} from './filter/PrincipalBrowseFilterPanel';
 import {Router} from '../Router';
 import {PrincipalServerEventsHandler} from '../event/PrincipalServerEventsHandler';
-import {IdProvider} from '../principal/IdProvider';
 import {TreeNode} from 'lib-admin-ui/ui/treegrid/TreeNode';
 import {BrowseItem} from 'lib-admin-ui/app/browse/BrowseItem';
 import {PrincipalType} from 'lib-admin-ui/security/PrincipalType';
-import {Principal} from 'lib-admin-ui/security/Principal';
 import {BrowsePanel} from 'lib-admin-ui/app/browse/BrowsePanel';
 import {AppHelper} from 'lib-admin-ui/util/AppHelper';
 import {i18n} from 'lib-admin-ui/util/Messages';
+import {PrincipalKey} from 'lib-admin-ui/security/PrincipalKey';
+import {IdProvider} from '../principal/IdProvider';
 
 export class UserBrowsePanel
     extends BrowsePanel<UserTreeGridItem> {
@@ -68,8 +68,8 @@ export class UserBrowsePanel
     private bindServerEventListeners() {
         const serverHandler = PrincipalServerEventsHandler.getInstance();
 
-        serverHandler.onUserItemCreated((principal: Principal, idProvider: IdProvider, sameTypeParent?: boolean) => {
-            this.treeGrid.appendUserNode(principal, idProvider, sameTypeParent);
+        serverHandler.onPrincipalCreated((key: PrincipalKey) => {
+            this.treeGrid.appendPrincipalNode(key);
             this.setRefreshOfFilterRequired();
 
             /*
@@ -81,8 +81,21 @@ export class UserBrowsePanel
             }
         });
 
-        serverHandler.onUserItemUpdated((principal: Principal, idProvider: IdProvider) => {
-            this.treeGrid.updateUserNode(principal, idProvider);
+        serverHandler.onIdProviderCreated((idProvider: IdProvider) => {
+            this.treeGrid.appendIdProviderUserNode(idProvider);
+            this.setRefreshOfFilterRequired();
+
+            if (this.isVisible()) {
+                this.refreshFilter();
+            }
+        });
+
+        serverHandler.onPrincipalUpdated((key: PrincipalKey) => {
+            this.treeGrid.updatePrincipalNode(key);
+        });
+
+        serverHandler.onIdProviderUpdated((idProvider: IdProvider) => {
+            this.treeGrid.updateIdProviderNode(idProvider);
         });
 
         serverHandler.onUserItemDeleted((ids: string[]) => {

--- a/src/main/resources/assets/js/app/browse/filter/PrincipalBrowseFilterPanel.ts
+++ b/src/main/resources/assets/js/app/browse/filter/PrincipalBrowseFilterPanel.ts
@@ -6,7 +6,6 @@ import {ListTypesRequest} from '../../../graphql/principal/ListTypesRequest';
 import {BrowseFilterResetEvent} from 'lib-admin-ui/app/browse/filter/BrowseFilterResetEvent';
 import {BrowseFilterSearchEvent} from 'lib-admin-ui/app/browse/filter/BrowseFilterSearchEvent';
 import {AggregationGroupView} from 'lib-admin-ui/aggregation/AggregationGroupView';
-import {AggregationSelection} from 'lib-admin-ui/aggregation/AggregationSelection';
 import {Aggregation} from 'lib-admin-ui/aggregation/Aggregation';
 import {BucketAggregation} from 'lib-admin-ui/aggregation/BucketAggregation';
 import {Bucket} from 'lib-admin-ui/aggregation/Bucket';
@@ -14,6 +13,7 @@ import {StringHelper} from 'lib-admin-ui/util/StringHelper';
 import {BrowseFilterPanel} from 'lib-admin-ui/app/browse/filter/BrowseFilterPanel';
 import {DefaultErrorHandler} from 'lib-admin-ui/DefaultErrorHandler';
 import {i18n} from 'lib-admin-ui/util/Messages';
+import {ListTypesResult} from '../../../graphql/principal/ListTypesResult';
 
 export class PrincipalBrowseFilterPanel
     extends BrowseFilterPanel<UserTreeGridItem> {
@@ -30,8 +30,8 @@ export class PrincipalBrowseFilterPanel
     }
 
     private initHitsCounter() {
-        new ListUserItemsRequest().sendAndParse().then((result: ListUserItemsRequestResult) => {
-            this.updateHitsCounter(result.userItems ? result.userItems.length : 0, true);
+        new ListTypesRequest().sendAndParse().then((result: ListTypesResult) => {
+            this.updateHitsCounter(result.getTotal(), true);
         }).catch((reason: any) => {
             DefaultErrorHandler.handle(reason);
         });
@@ -77,11 +77,6 @@ export class PrincipalBrowseFilterPanel
         }).catch((reason: any) => {
             DefaultErrorHandler.handle(reason);
         });
-    }
-
-    private hasSelectedAggregations(): boolean {
-        const selections: AggregationSelection[] = this.getSearchInputValues().aggregationSelections || [];
-        return selections.some(selection => selection.getSelectedBuckets().length > 0);
     }
 
     private getCheckedTypes(): UserItemType[] {
@@ -163,9 +158,9 @@ export class PrincipalBrowseFilterPanel
         return new ListTypesRequest()
             .setQuery(searchString)
             .sendAndParse()
-            .then((typeAggregation) => {
-                this.updateAggregations([typeAggregation], true);
-                this.toggleAggregationsVisibility([typeAggregation]);
+            .then((result: ListTypesResult) => {
+                this.updateAggregations([result.getBucketAggregation()], true);
+                this.toggleAggregationsVisibility([result.getBucketAggregation()]);
             }).catch((reason: any) => {
                 DefaultErrorHandler.handle(reason);
             });

--- a/src/main/resources/assets/js/app/view/UserItemStatisticsPanel.ts
+++ b/src/main/resources/assets/js/app/view/UserItemStatisticsPanel.ts
@@ -78,9 +78,11 @@ export class UserItemStatisticsPanel
 
         const serverHandler = PrincipalServerEventsHandler.getInstance();
 
-        serverHandler.onUserItemCreated(handler);
+        serverHandler.onPrincipalCreated(handler);
+        serverHandler.onIdProviderCreated(handler);
         serverHandler.onUserItemDeleted(handler);
-        serverHandler.onUserItemUpdated(handler);
+        serverHandler.onPrincipalUpdated(handler);
+        serverHandler.onIdProviderUpdated(handler);
     }
 
     private handleUserItemEvent() {

--- a/src/main/resources/assets/js/graphql/principal/ListTypesRequest.ts
+++ b/src/main/resources/assets/js/graphql/principal/ListTypesRequest.ts
@@ -2,9 +2,10 @@ import {ListGraphQlRequest} from '../ListGraphQlRequest';
 import {UserItemAggregationHelper} from '../aggregation/UserItemAggregationHelper';
 import {UserItemBucketAggregationJson} from '../aggregation/UserItemBucketAggregationJson';
 import {BucketAggregation} from 'lib-admin-ui/aggregation/BucketAggregation';
+import {ListTypesResult} from './ListTypesResult';
 
 export class ListTypesRequest
-    extends ListGraphQlRequest<any, any> {
+    extends ListGraphQlRequest<any, ListTypesResult> {
 
     private searchQuery: string;
 
@@ -38,10 +39,11 @@ export class ListTypesRequest
                 }`;
     }
 
-    sendAndParse(): Q.Promise<BucketAggregation> {
+    sendAndParse(): Q.Promise<ListTypesResult> {
         return this.query().then((response: any) => {
             const data = response.types;
-            return this.fromJsonToAggregation(data.aggregations);
+            const aggregation: BucketAggregation = this.fromJsonToAggregation(data.aggregations);
+            return new ListTypesResult(aggregation, data.totalCount);
         });
     }
 

--- a/src/main/resources/assets/js/graphql/principal/ListTypesResult.ts
+++ b/src/main/resources/assets/js/graphql/principal/ListTypesResult.ts
@@ -1,0 +1,22 @@
+import {BucketAggregation} from 'lib-admin-ui/aggregation/BucketAggregation';
+
+export class ListTypesResult {
+
+    private total: number;
+
+    private bucketAggregation: BucketAggregation;
+
+    constructor(bucketAggregation: BucketAggregation, total: number) {
+        this.bucketAggregation = bucketAggregation;
+        this.total = total;
+    }
+
+    getBucketAggregation(): BucketAggregation {
+        return this.bucketAggregation;
+    }
+
+    getTotal(): number {
+        return this.total;
+    }
+
+}


### PR DESCRIPTION
Create and Update operations in UserItemsTreeGrid were updated considering next possible situations:
1. Adding new principal (role, user, group) node: first of all NOT FETCHING blindly principal from backend, first making sure that fetch is required
	a) If parent node where new principal is supposed to occur is not in grid yet or wasn't expanded (thus children were not loaded yet) then doing nothing
	b) If parent node is found and not empty, then if it has N children loaded of Y total then fetching N children, thus new item will be loaded among them if it is supposed to be there
2. Updating principal node: fetching principal only if it's node is in grid
3. Adding new IdProvider: all IdProviders are displayed immediately in grid root, thus fetching newly added IdProvider immediately, defining insert index and adding it into grid
4. Updating IdProvider: fetching updated IdProvider immediately, identifying it's node and updating it