### PR TITLE
NPE after deleting a group or user #325

### DIFF
--- a/src/main/resources/assets/js/app/event/PrincipalServerEventsHandler.ts
+++ b/src/main/resources/assets/js/app/event/PrincipalServerEventsHandler.ts
@@ -165,7 +165,7 @@ export class PrincipalServerEventsHandler {
 
         if (key.isRole()) {
             return this.fetchPrincipal(key).then(principal => {
-                return {principal}
+                return {principal};
             });
         }
 


### PR DESCRIPTION
-Deleting user item spawns 2 events for deleted item: update and delete, but update is handled after delete, thus requesting "updated" item leads to NPE.
Fixed by filtering deleted items before invoking update handler