### PR TITLE
BrowsePanel: unify handling of TreeGrid data change event throughout …

### DIFF
--- a/src/main/resources/assets/js/app/UserAppPanel.ts
+++ b/src/main/resources/assets/js/app/UserAppPanel.ts
@@ -48,7 +48,7 @@ interface PrincipalData {
 }
 
 export class UserAppPanel
-    extends NavigatedAppPanel<UserTreeGridItem> {
+    extends NavigatedAppPanel {
 
     private mask: LoadMask;
 

--- a/src/main/resources/assets/js/app/browse/UserBrowseItemPanel.ts
+++ b/src/main/resources/assets/js/app/browse/UserBrowseItemPanel.ts
@@ -1,12 +1,11 @@
-import {UserTreeGridItem} from './UserTreeGridItem';
 import {UserItemStatisticsPanel} from '../view/UserItemStatisticsPanel';
 import {BrowseItemPanel} from 'lib-admin-ui/app/browse/BrowseItemPanel';
 import {ItemStatisticsPanel} from 'lib-admin-ui/app/view/ItemStatisticsPanel';
 
 export class UserBrowseItemPanel
-    extends BrowseItemPanel<UserTreeGridItem> {
+    extends BrowseItemPanel {
 
-    createItemStatisticsPanel(): ItemStatisticsPanel<UserTreeGridItem> {
+    createItemStatisticsPanel(): ItemStatisticsPanel {
         return new UserItemStatisticsPanel();
     }
 

--- a/src/main/resources/assets/js/app/browse/UserBrowsePanel.ts
+++ b/src/main/resources/assets/js/app/browse/UserBrowsePanel.ts
@@ -16,7 +16,7 @@ import {AppHelper} from 'lib-admin-ui/util/AppHelper';
 import {i18n} from 'lib-admin-ui/util/Messages';
 
 export class UserBrowsePanel
-    extends BrowsePanel<UserTreeGridItem> {
+    extends BrowsePanel {
 
     protected treeGrid: UserItemsTreeGrid;
 
@@ -129,13 +129,6 @@ export class UserBrowsePanel
         this.filterPanel.resetConstraints();
         this.hideFilterPanel();
         super.disableSelectionMode();
-    }
-
-    dataToBrowseItem(data: UserTreeGridItem): BrowseItem<UserTreeGridItem> | null {
-        return <BrowseItem<UserTreeGridItem>>new BrowseItem<UserTreeGridItem>(data)
-            .setId(data.getId())
-            .setDisplayName(data.getItemDisplayName())
-            .setIconClass(this.selectIconClass(data));
     }
 
     private selectIconClass(item: UserTreeGridItem): string {

--- a/src/main/resources/assets/js/app/browse/UserBrowsePanel.ts
+++ b/src/main/resources/assets/js/app/browse/UserBrowsePanel.ts
@@ -7,8 +7,6 @@ import {PrincipalBrowseFilterPanel} from './filter/PrincipalBrowseFilterPanel';
 import {Router} from '../Router';
 import {PrincipalServerEventsHandler} from '../event/PrincipalServerEventsHandler';
 import {IdProvider} from '../principal/IdProvider';
-import {TreeNode} from 'lib-admin-ui/ui/treegrid/TreeNode';
-import {BrowseItem} from 'lib-admin-ui/app/browse/BrowseItem';
 import {PrincipalType} from 'lib-admin-ui/security/PrincipalType';
 import {Principal} from 'lib-admin-ui/security/Principal';
 import {BrowsePanel} from 'lib-admin-ui/app/browse/BrowsePanel';

--- a/src/main/resources/assets/js/app/browse/UserTreeGridActions.ts
+++ b/src/main/resources/assets/js/app/browse/UserTreeGridActions.ts
@@ -38,17 +38,15 @@ export class UserTreeGridActions implements TreeGridActions<UserTreeGridItem> {
         return this.actions;
     }
 
-    updateActionsEnabledState(browseItems: BrowseItem<UserTreeGridItem>[],
-                              changes?: BrowseItemsChanges<UserTreeGridItem>): Q.Promise<void> {
+    updateActionsEnabledState(items: UserTreeGridItem[]): Q.Promise<void> {
         return Q(true).then(() => {
             let idProvidersSelected: number = 0;
             let principalsSelected: number = 0;
             let directoriesSelected: number = 0;
             let usersSelected: number = 0;
 
-            browseItems.forEach((browseItem: BrowseItem<UserTreeGridItem>) => {
-                const item = <UserTreeGridItem>browseItem.getModel();
-                const itemType = item.getType();
+            items.forEach((item: UserTreeGridItem) => {
+                const itemType: UserTreeGridItemType = item.getType();
                 switch (itemType) {
                 case UserTreeGridItemType.PRINCIPAL:
                     principalsSelected++;
@@ -79,12 +77,12 @@ export class UserTreeGridActions implements TreeGridActions<UserTreeGridItem> {
 
             this.EDIT.setEnabled(directoriesSelected < 1 && (anyIdProvider || anyPrincipal));
 
-            if (this.isSystemUserItemSelected(browseItems)) {
+            if (this.isSystemUserItemSelected(items)) {
                 this.DELETE.setEnabled(false);
             } else if (onlyUsersSelected || onePrincipalSelected) {
                 this.DELETE.setEnabled(true);
             } else if (totalSelection === 1) {
-                this.establishDeleteActionState((<BrowseItem<UserTreeGridItem>>browseItems[0]).getModel());
+                this.establishDeleteActionState(items[0]);
             } else {
                 this.DELETE.setEnabled(false);
             }
@@ -93,10 +91,10 @@ export class UserTreeGridActions implements TreeGridActions<UserTreeGridItem> {
         });
     }
 
-    private isSystemUserItemSelected(browseItems: BrowseItem<UserTreeGridItem>[]) {
-        const principals: Principal[] = browseItems
-            .filter(item => (<BrowseItem<UserTreeGridItem>>item).getModel().isPrincipal())
-            .map(item => (<BrowseItem<UserTreeGridItem>>item).getModel().getPrincipal());
+    private isSystemUserItemSelected(items: UserTreeGridItem[]) {
+        const principals: Principal[] = items
+            .filter((item: UserTreeGridItem) => item.isPrincipal())
+            .map((item: UserTreeGridItem) => item.getPrincipal());
 
         return principals.some(principal => principal.isSystem());
     }

--- a/src/main/resources/assets/js/app/browse/UserTreeGridActions.ts
+++ b/src/main/resources/assets/js/app/browse/UserTreeGridActions.ts
@@ -9,8 +9,6 @@ import {User} from '../principal/User';
 import {IdProvider} from '../principal/IdProvider';
 import {Action} from 'lib-admin-ui/ui/Action';
 import {TreeGridActions} from 'lib-admin-ui/ui/treegrid/actions/TreeGridActions';
-import {BrowseItem} from 'lib-admin-ui/app/browse/BrowseItem';
-import {BrowseItemsChanges} from 'lib-admin-ui/app/browse/BrowseItemsChanges';
 import {Principal} from 'lib-admin-ui/security/Principal';
 import {ObjectHelper} from 'lib-admin-ui/ObjectHelper';
 import {DefaultErrorHandler} from 'lib-admin-ui/DefaultErrorHandler';

--- a/src/main/resources/assets/js/app/browse/UserTreeGridItem.ts
+++ b/src/main/resources/assets/js/app/browse/UserTreeGridItem.ts
@@ -5,7 +5,7 @@ import {IdProvider} from '../principal/IdProvider';
 import {Equitable} from 'lib-admin-ui/Equitable';
 import {ObjectHelper} from 'lib-admin-ui/ObjectHelper';
 import {i18n} from 'lib-admin-ui/util/Messages';
-import {IDentifiable} from 'lib-admin-ui/IDentifiable';
+import {ViewItem} from 'lib-admin-ui/app/view/ViewItem';
 
 export enum UserTreeGridItemType {
     ID_PROVIDER,
@@ -16,7 +16,7 @@ export enum UserTreeGridItemType {
 }
 
 export class UserTreeGridItem
-    implements Equitable, IDentifiable {
+    implements ViewItem {
 
     private idProvider: IdProvider;
 
@@ -135,8 +135,8 @@ export class UserTreeGridItem
             return false;
         }
 
-        let other = <UserTreeGridItem> o;
-        return this.principal === other.getPrincipal() && this.idProvider === other.getIdProvider();
+        const other:UserTreeGridItem = <UserTreeGridItem> o;
+        return this.type === other.getType() && this.principal === other.getPrincipal() && this.idProvider === other.getIdProvider();
     }
 
     static create(): UserTreeGridItemBuilder {
@@ -162,6 +162,42 @@ export class UserTreeGridItem
         default:
             return null;
         }
+    }
+
+    getDisplayName(): string {
+        return this.getItemDisplayName();
+    }
+
+    getIconClass(): string {
+        switch (this.getType()) {
+        case UserTreeGridItemType.ID_PROVIDER:
+            return 'icon-address-book icon-large';
+
+        case UserTreeGridItemType.PRINCIPAL:
+            if (this.getPrincipal().isRole()) {
+                return 'icon-masks icon-large';
+
+            } else if (this.getPrincipal().isUser()) {
+                return 'icon-user icon-large';
+
+            } else if (this.getPrincipal().isGroup()) {
+                return 'icon-users icon-large';
+            }
+            break;
+
+        case UserTreeGridItemType.GROUPS:
+            return 'icon-folder icon-large';
+
+        case UserTreeGridItemType.ROLES:
+            return 'icon-folder icon-large';
+
+        case UserTreeGridItemType.USERS:
+            return 'icon-folder icon-large';
+        }
+    }
+
+    getIconUrl(): string {
+        return '';
     }
 }
 

--- a/src/main/resources/assets/js/app/view/UserItemStatisticsHeader.ts
+++ b/src/main/resources/assets/js/app/view/UserItemStatisticsHeader.ts
@@ -1,0 +1,20 @@
+import {ItemStatisticsHeader} from 'lib-admin-ui/app/view/ItemStatisticsHeader';
+import {UserTreeGridItem, UserTreeGridItemType} from '../browse/UserTreeGridItem';
+
+export class UserItemStatisticsHeader
+    extends ItemStatisticsHeader {
+
+    setItem(item: UserTreeGridItem): void {
+        super.setItem(item);
+
+        if (item.getType() === UserTreeGridItemType.PRINCIPAL) {
+            this.appendToHeaderPath(item.getPrincipal().getKey().toPath(true), 'parent-path');
+            this.appendToHeaderPath(item.getPrincipal().getKey().getId(), 'path-name');
+        }
+
+    }
+
+    protected getIconSize(item: UserTreeGridItem): number {
+        return item.getType() === UserTreeGridItemType.PRINCIPAL ? 128 : super.getIconSize(item);
+    }
+}


### PR DESCRIPTION
…all BrowsePanel inheritors #477

-handling selection change and highlighting change in one place in BrowsePanel
-Using unified ViewItem interface throughout BrowsePanel and it's grid and other classes to wrap actual data so inheritors could easily extend it
-removed unused and redundant classes
-moved some Content classes out of lib-admin-ui (ContentIconUrlResolver, ContentSummaryViewer)
-removed creation of header in ItemStatisticsPanel so it to be used on demand
-moved check of item to be renderable out of lib-admin-ui since it is only relevant in content studio where we render content on preview
-refactored check of content to be renderable: now doing check when fetching ContentSummaryAndCompareStatus to
a) avoid spaghetti code actions check and item preview logic
b) skip fetching isRenderable request for same item when navigating in TreeGrid, we currentlyload items in ContentTreeGrid by 10, so won't be a problem to fetch it immediately since request is lightweight