### PR TITLE
Users and Groups wizards - data (email, members) are cleared after op…

### DIFF
--- a/src/main/resources/assets/js/app/UserAppPanel.ts
+++ b/src/main/resources/assets/js/app/UserAppPanel.ts
@@ -397,8 +397,7 @@ export class UserAppPanel
             .setPersistedType(principal.getType())
             .setPersistedPath(principal.getKey().toPath(true))
             .setTabId(tabId)
-            .setPersistedDisplayName(principal.getDisplayName())
-            .setPersistedItem(principal);
+            .setPersistedDisplayName(principal.getDisplayName());
 
         let wizard = this.resolvePrincipalWizardPanel(wizardParams);
 


### PR DESCRIPTION
…ening existing group, user #633

-Making Principal wizard panel load full principal data when wizard is open (browse panel treegrid contains limited data on items)