### PR TITLE
Error in group selector inside ID providers config form (#940)

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/authapplicationselector/AuthApplicationSelectedOptionsView.ts
+++ b/src/main/resources/assets/js/app/inputtype/authapplicationselector/AuthApplicationSelectedOptionsView.ts
@@ -5,7 +5,6 @@ import {Option} from 'lib-admin-ui/ui/selector/Option';
 import {SelectedOption} from 'lib-admin-ui/ui/selector/combobox/SelectedOption';
 import {BaseSelectedOptionsView} from 'lib-admin-ui/ui/selector/combobox/BaseSelectedOptionsView';
 import {ApplicationConfigProvider} from 'lib-admin-ui/form/inputtype/appconfig/ApplicationConfigProvider';
-import {FormContext} from 'lib-admin-ui/form/FormContext';
 import {AuthApplicationSelectedOptionView} from './AuthApplicationSelectedOptionView';
 
 export class AuthApplicationSelectedOptionsView

--- a/src/main/resources/assets/js/app/inputtype/selector/PrincipalSelector.ts
+++ b/src/main/resources/assets/js/app/inputtype/selector/PrincipalSelector.ts
@@ -1,0 +1,16 @@
+import {PrincipalSelector as BasePrincipalSelector} from 'lib-admin-ui/form/inputtype/principal/PrincipalSelector';
+import {PrincipalLoader as BasePrincipalLoader} from 'lib-admin-ui/security/PrincipalLoader';
+import {PrincipalLoader} from '../../principal/PrincipalLoader';
+import {InputTypeName} from 'lib-admin-ui/form/InputTypeName';
+
+export class PrincipalSelector
+    extends BasePrincipalSelector {
+
+    protected createLoader(): BasePrincipalLoader {
+        return new PrincipalLoader();
+    }
+
+    static getName(): InputTypeName {
+        return new InputTypeName('PrincipalSelector', false);
+    }
+}

--- a/src/main/resources/assets/js/main.ts
+++ b/src/main/resources/assets/js/main.ts
@@ -14,6 +14,9 @@ import {TabbedAppBar} from 'lib-admin-ui/app/bar/TabbedAppBar';
 import {AppHelper} from 'lib-admin-ui/util/AppHelper';
 import {i18nInit} from 'lib-admin-ui/util/MessagesInitializer';
 import {CONFIG} from 'lib-admin-ui/util/Config';
+import {PrincipalSelector} from './app/inputtype/selector/PrincipalSelector';
+import {InputTypeManager} from 'lib-admin-ui/form/inputtype/InputTypeManager';
+import {Class} from 'lib-admin-ui/Class';
 
 const body = Body.get();
 
@@ -86,3 +89,5 @@ function startApplication() {
     await i18nInit(CONFIG.getString('services.i18nUrl'));
     startApplication();
 })();
+
+InputTypeManager.register(new Class('PrincipalSelector', PrincipalSelector), true);


### PR DESCRIPTION
IDP config creates an instance of the `PrincipalSelector`'s base class which is using "common" API which no longer exists in XP. This PR fixes the following:
1) Implements app-specific `PrincipalSelector`
2) Registers it in the `InputType` registry