### PR TITLE
Fixed ListUserItemsRequest performance (#1035)

### DIFF
--- a/src/main/resources/assets/js/app/event/UserFilteredDataScrollEvent.ts
+++ b/src/main/resources/assets/js/app/event/UserFilteredDataScrollEvent.ts
@@ -1,0 +1,25 @@
+import {ClassHelper} from 'lib-admin-ui/ClassHelper';
+import {Event} from 'lib-admin-ui/event/Event';
+
+export class UserFilteredDataScrollEvent
+    extends Event {
+
+    private count: number;
+
+    constructor(count: number) {
+        super();
+        this.count = count;
+    }
+
+    public getCount(): number {
+        return this.count;
+    }
+
+    static on(handler: (event: UserFilteredDataScrollEvent) => void): void {
+        Event.bind(ClassHelper.getFullName(this), handler);
+    }
+
+    static un(handler?: (event: UserFilteredDataScrollEvent) => void): void {
+        Event.unbind(ClassHelper.getFullName(this), handler);
+    }
+}

--- a/src/main/resources/assets/js/app/principal/IdProvider.ts
+++ b/src/main/resources/assets/js/app/principal/IdProvider.ts
@@ -39,9 +39,11 @@ export class IdProvider
     }
 
     isDeletable(): Q.Promise<boolean> {
+        // setCount(1): Only total is used, so there's no need to traverse everything.
         return new ListPrincipalsRequest()
             .setIdProviderKey(this.getKey())
             .setTypes([PrincipalType.USER, PrincipalType.GROUP])
+            .setCount(0)
             .sendAndParse()
             .then((result: ListPrincipalsData) => (result.total === 0));
     }

--- a/src/main/resources/assets/js/app/principal/PrincipalLoader.ts
+++ b/src/main/resources/assets/js/app/principal/PrincipalLoader.ts
@@ -7,7 +7,7 @@ export class PrincipalLoader
     extends BasePrincipalLoader {
 
     protected createRequest(): FindPrincipalsRequest {
-        return <FindPrincipalsRequest>new FindPrincipalsRequest().setSize(-1);
+        return <FindPrincipalsRequest>new FindPrincipalsRequest().setSize(30);
     }
 
     protected createPreLoadRequest(principalKeys: PrincipalKey[]): GetPrincipalsByKeysRequest {

--- a/src/main/resources/assets/js/graphql/ListGraphQlRequest.ts
+++ b/src/main/resources/assets/js/graphql/ListGraphQlRequest.ts
@@ -33,7 +33,7 @@ export class ListGraphQlRequest<PARSED_TYPE>
         if (this.start > 0) {
             vars['start'] = this.start;
         }
-        if (this.count > 0) {
+        if (this.count >= 0) {
             vars['count'] = this.count;
         }
         if (!!this.sort) {

--- a/src/main/resources/assets/js/graphql/principal/GetPrincipalsExistenceRequest.ts
+++ b/src/main/resources/assets/js/graphql/principal/GetPrincipalsExistenceRequest.ts
@@ -3,24 +3,29 @@ import {PrincipalType} from 'lib-admin-ui/security/PrincipalType';
 import {IdProviderKey} from 'lib-admin-ui/security/IdProviderKey';
 import {ListPrincipalsProperties} from './ListPrincipalsNamesRequest';
 
-type GetPrincipalsTotalResult = {
+type GetPrincipalsExistenceRequestResult = {
     principalsConnection: {
         totalCount: number
     }
 };
 
-export class GetPrincipalsTotalRequest
-    extends ListGraphQlRequest<number> {
+export class GetPrincipalsExistenceRequest
+    extends ListGraphQlRequest<boolean> {
 
     private types: PrincipalType[];
     private idProviderKey: IdProviderKey;
 
-    setTypes(types: PrincipalType[]): GetPrincipalsTotalRequest {
+    constructor() {
+        super();
+        this.setCount(0);
+    }
+
+    setTypes(types: PrincipalType[]): GetPrincipalsExistenceRequest {
         this.types = types;
         return this;
     }
 
-    setIdProviderKey(key: IdProviderKey): GetPrincipalsTotalRequest {
+    setIdProviderKey(key: IdProviderKey): GetPrincipalsExistenceRequest {
         this.idProviderKey = key;
         return this;
     }
@@ -45,10 +50,9 @@ export class GetPrincipalsTotalRequest
                 }`;
     }
 
-    sendAndParse(): Q.Promise<number> {
-        return this.query().then((response: GetPrincipalsTotalResult) => {
-            const data = response.principalsConnection;
-            return data.totalCount;
+    sendAndParse(): Q.Promise<boolean> {
+        return this.query().then((response: GetPrincipalsExistenceRequestResult) => {
+            return response.principalsConnection.totalCount > 0;
         });
     }
 }

--- a/src/main/resources/assets/js/graphql/principal/ListTypesRequest.ts
+++ b/src/main/resources/assets/js/graphql/principal/ListTypesRequest.ts
@@ -13,6 +13,12 @@ type ListTypeData = {
 export class ListTypesRequest
     extends ListItemsRequest<BucketAggregation> {
 
+    constructor(){
+        super();
+        // No need to go through everything since the only data used in the response is from aggregations
+        this.setCount(1);
+    }
+
     getQuery(): string {
         return `query ($query: String, $itemIds: [String], $start: Int, $count: Int) {
                     types (query: $query, itemIds: $itemIds, start: $start, count: $count) {
@@ -30,8 +36,7 @@ export class ListTypesRequest
 
     sendAndParse(): Q.Promise<BucketAggregation> {
         return this.query().then((response: ListTypeData) => {
-            const data = response.types;
-            return this.fromJsonToAggregation(data.aggregations);
+            return this.fromJsonToAggregation(response.types.aggregations);
         });
     }
 

--- a/src/main/resources/assets/js/graphql/principal/ListUserItemsRequest.ts
+++ b/src/main/resources/assets/js/graphql/principal/ListUserItemsRequest.ts
@@ -19,7 +19,7 @@ import {ListItemsProperties, ListItemsRequest} from './ListItemsRequest';
 // UserItems does not map "name" property. Missing type? or wrong graph query?
 export type ListUserItemsRequestResult = {
     total: number,
-    userItems: UserItem[], 
+    userItems: UserItem[],
     aggregations: BucketAggregation[]
 };
 
@@ -37,7 +37,7 @@ interface ListUserItemsGraph {
                 description: string;
                 displayName: string;
             }
-        }], 
+        }],
         aggregations: UserItemBucketAggregationJson[];
     }
 }
@@ -46,6 +46,15 @@ export class ListUserItemsRequest
     extends ListItemsRequest<ListUserItemsRequestResult> {
 
     private types: UserItemType[];
+
+    constructor(){
+        super();
+    }
+
+    setCount(value: number): ListUserItemsRequest {
+        this.count = value;
+        return this;
+    }
 
     setTypes(types: UserItemType[]): ListUserItemsRequest {
         this.types = types;


### PR DESCRIPTION
The idea here was a bit more complicated... there are multiple instances of the `ListUserItemsRequest` class. Here they are:

UserItemsTreeGrid:
- https://github.com/enonic/app-users/blob/master/src/main/resources/assets/js/app/browse/UserItemsTreeGrid.ts#L254

PrincipalBrowseFilterPanel:
- https://github.com/enonic/app-users/blob/master/src/main/resources/assets/js/app/browse/filter/PrincipalBrowseFilterPanel.ts#L36
- https://github.com/enonic/app-users/blob/master/src/main/resources/assets/js/app/browse/filter/PrincipalBrowseFilterPanel.ts#L69
- https://github.com/enonic/app-users/blob/master/src/main/resources/assets/js/app/browse/filter/PrincipalBrowseFilterPanel.ts#L99
- https://github.com/enonic/app-users/blob/master/src/main/resources/assets/js/app/browse/filter/PrincipalBrowseFilterPanel.ts#L112

So for instances where the necessary data does not depend on the count parameter, I simply set the count to 1:
- https://github.com/enonic/app-users/blob/master/src/main/resources/assets/js/app/browse/filter/PrincipalBrowseFilterPanel.ts#L36
- https://github.com/enonic/app-users/blob/master/src/main/resources/assets/js/app/browse/filter/PrincipalBrowseFilterPanel.ts#L69

For the remaining instances, I couldn't just set the counter to one, because the data used is actually the users, so by setting counter to `N`, we'd be showing only `N` users after some search for example.

Therefore my approach was to set them to `100`, and only if the users scroll down the filtered data, then we'll request `100 + N`, `100 + 2N`, ...  number of users. 

Why request `100 + N`, instead of requesting `N` and append the response the current data? Because this data comes from a search, so the `N` new ones might not have anything related to the old ones.

If approved, than I'd like to know how to add the "loading" effect, just like when loading through all users under an idProvider (`loadChildren` method), that's why this PR is currently a draft.
