### PR TITLE
Test under lib/auth/ are skipped #1418

### DIFF
--- a/src/test/java/com/enonic/xp/app/users/lib/auth/CreateIdProviderHandlerTest.java
+++ b/src/test/java/com/enonic/xp/app/users/lib/auth/CreateIdProviderHandlerTest.java
@@ -2,7 +2,7 @@ package com.enonic.xp.app.users.lib.auth;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 

--- a/src/test/java/com/enonic/xp/app/users/lib/auth/DefaultPermissionsHandlerTest.java
+++ b/src/test/java/com/enonic/xp/app/users/lib/auth/DefaultPermissionsHandlerTest.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.app.users.lib.auth;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.enonic.xp.security.IdProviderKey;

--- a/src/test/java/com/enonic/xp/app/users/lib/auth/DeleteIdProvidersHandlerTest.java
+++ b/src/test/java/com/enonic/xp/app/users/lib/auth/DeleteIdProvidersHandlerTest.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.app.users.lib.auth;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.enonic.xp.security.IdProviderKey;

--- a/src/test/java/com/enonic/xp/app/users/lib/auth/GetIdProviderHandlerTest.java
+++ b/src/test/java/com/enonic/xp/app/users/lib/auth/GetIdProviderHandlerTest.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.app.users.lib.auth;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.enonic.xp.security.IdProviderKey;

--- a/src/test/java/com/enonic/xp/app/users/lib/auth/GetPermissionsHandlerTest.java
+++ b/src/test/java/com/enonic/xp/app/users/lib/auth/GetPermissionsHandlerTest.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.app.users.lib.auth;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.enonic.xp.security.Group;

--- a/src/test/java/com/enonic/xp/app/users/lib/auth/ModifyIdProviderHandlerTest.java
+++ b/src/test/java/com/enonic/xp/app/users/lib/auth/ModifyIdProviderHandlerTest.java
@@ -3,7 +3,7 @@ package com.enonic.xp.app.users.lib.auth;
 import java.util.Optional;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.enonic.xp.security.EditableIdProvider;


### PR DESCRIPTION
Fixed imported texts annotations, so the tests become discoverable again.