### PR TITLE
Fix selenium tests broken by cms.cm.app role removal

### DIFF
--- a/testing/libs/app_const.js
+++ b/testing/libs/app_const.js
@@ -62,7 +62,7 @@ module.exports = Object.freeze({
     ROLES_DISPLAY_NAME: {
         CM_ADMIN: 'Content Manager Administrator',
         ADMIN_CONSOLE: 'Administration Console Login',
-        CM_APP: 'Content Manager App',
+        CM_EXPERT: 'Content Manager Expert',
         ADMINISTRATOR: 'Administrator',
         USERS_APP: 'Users App',
         AUTHENTICATED: 'Authenticated',
@@ -71,6 +71,7 @@ module.exports = Object.freeze({
     },
     ROLES_NAME: {
         CM_ADMIN: 'cms.admin',
+        CM_EXPERT: 'cms.expert',
         ADMINISTRATOR: 'system.admin',
         USERS_APP: 'system.user.admin',
     },

--- a/testing/tests/browse.toolbar.shortcut.spec.js
+++ b/testing/tests/browse.toolbar.shortcut.spec.js
@@ -39,7 +39,7 @@ describe('User Browse panel, toolbar shortcut spec', function () {
     it(`GIVEN cms role is selected WHEN 'Ctrl+del' has been pressed THEN Confirmation Dialog should appear`,
         async () => {
             let userBrowsePanel = new UserBrowsePanel();
-            let roleName = 'cms.cm.app';
+            let roleName = appConst.ROLES_NAME.CM_EXPERT;
             await testUtils.findAndSelectItem(roleName);
             await userBrowsePanel.hotKeyDelete();
             await testUtils.saveScreenshot('hot_key_delete_role');

--- a/testing/tests/user.with.generated.password.spec.js
+++ b/testing/tests/user.with.generated.password.spec.js
@@ -25,7 +25,7 @@ describe("Create an user with generated password and do login with the user", fu
 
     it("WHEN new 'user' with required roles has been added THEN the user should be searchable",
         async () => {
-            let permissions = ['Administration Console Login', 'Content Manager App'];
+            let permissions = [appConst.ROLES_DISPLAY_NAME.ADMIN_CONSOLE, appConst.ROLES_DISPLAY_NAME.CM_EXPERT];
             let userWizard = new UserWizard();
             let userBrowsePanel = new UserBrowsePanel();
             let changePasswordDialog = new ChangePasswordDialog();

--- a/testing/tests/userroles.and.home.page.links.spec.js
+++ b/testing/tests/userroles.and.home.page.links.spec.js
@@ -24,7 +24,7 @@ describe('Checks links on Home Page when an user has no administrator role', fun
 
     it("WHEN new user with required roles has been added THEN the user should be searchable",
         async () => {
-            let roles = ['Administration Console Login', 'Content Manager App'];
+            let roles = [appConst.ROLES_DISPLAY_NAME.ADMIN_CONSOLE, appConst.ROLES_DISPLAY_NAME.CM_EXPERT];
             userName = userItemsBuilder.generateRandomName('user');
             let userWizard = new UserWizard();
             let userBrowsePanel = new UserBrowsePanel();


### PR DESCRIPTION
## Summary

The role `cms.cm.app` ("Content Manager App") was deprecated on XP master in [xp#12034 ("Deprecate cms.cm.app role #12023")](https://github.com/enonic/xp/pull/12034) and is no longer auto-created by `SecurityInitializer` on a fresh install. Three selenium specs still rely on its presence and started failing on the master CI run [25808224515](https://github.com/enonic/app-users/actions/runs/25808224515/job/75818883434).

Switched the references to `cms.expert` / "Content Manager Expert", which is still seeded by `SecurityInitializer` on XP 8.1+ and serves the same purpose in these tests (a CM-side, non-system-admin role).

## Specs touched

- `testing/tests/browse.toolbar.shortcut.spec.js` — the "Ctrl+del on a cms role" case now selects `cms.expert`.
- `testing/tests/user.with.generated.password.spec.js` — user wizard Roles combobox now picks "Content Manager Expert".
- `testing/tests/userroles.and.home.page.links.spec.js` — same. The test's intent (verifying that a user with no Administrator role does not see Applications/Users on the Home page) is preserved; CM Expert is also not a system-admin role.

`testing/libs/app_const.js`: replaced `ROLES_DISPLAY_NAME.CM_APP` with `CM_EXPERT`, and added `ROLES_NAME.CM_EXPERT: 'cms.expert'`.

## Why master only

The 8.0 branch still ships the legacy role on its XP build, so this PR targets `master` only.

## Test plan

- [ ] `selenium-test (w_testUsersApp)` job on this PR is green.
- [ ] The three previously failing specs now pass.
- [ ] No other spec regressed by the constants rename in `app_const.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)