### PR TITLE
GraalJS Compatibility #2599

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,6 @@ dependencies {
     testImplementation libs.mockito.jupiter
     testImplementation testFixtures( "com.enonic.xp:jaxrs-impl:${xpVersion}" )
     testRuntimeOnly libs.junit.launcher
-    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 app {
@@ -157,16 +156,9 @@ tasks.named( 'test' ).configure {
     jvmArgs '-XX:TieredStopAtLevel=1'
 }
 
-def testGraalJs = tasks.register( 'testGraalJs', Test ) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-check.dependsOn testGraalJs
 
 tasks.named( 'jacocoTestReport' ).configure {
     reports {

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     testImplementation libs.mockito.jupiter
     testImplementation testFixtures( "com.enonic.xp:jaxrs-impl:${xpVersion}" )
     testRuntimeOnly libs.junit.launcher
+    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 app {
@@ -155,6 +156,17 @@ tasks.named( 'test' ).configure {
     systemProperty 'java.awt.headless', 'true'
     jvmArgs '-XX:TieredStopAtLevel=1'
 }
+
+def testGraalJs = tasks.register( 'testGraalJs', Test ) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+check.dependsOn testGraalJs
 
 tasks.named( 'jacocoTestReport' ).configure {
     reports {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.enonic.xp.settings' version '4.1.0'
+    id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 include 'testing'

--- a/src/main/resources/apis/graphql/utils.js
+++ b/src/main/resources/apis/graphql/utils.js
@@ -9,5 +9,5 @@ exports.toArray = function(object) {
 };
 
 exports.toInt = function(number, defaultValue) {
-    return number == null ? defaultValue.intValue() : number.intValue();
+    return number == null ? defaultValue : Number(number);
 };

--- a/src/test/java/com/enonic/xp/app/users/apis/graphql/UtilsTest.java
+++ b/src/test/java/com/enonic/xp/app/users/apis/graphql/UtilsTest.java
@@ -1,0 +1,27 @@
+package com.enonic.xp.app.users.apis.graphql;
+
+import org.junit.jupiter.api.Test;
+
+import com.enonic.xp.testing.ScriptTestSupport;
+
+public class UtilsTest
+    extends ScriptTestSupport
+{
+    @Test
+    public void toIntFromNumber()
+    {
+        runFunction( "/com/enonic/xp/app/users/apis/graphql/utils-test.js", "toIntFromNumber" );
+    }
+
+    @Test
+    public void toIntFromString()
+    {
+        runFunction( "/com/enonic/xp/app/users/apis/graphql/utils-test.js", "toIntFromString" );
+    }
+
+    @Test
+    public void toIntNullReturnsDefault()
+    {
+        runFunction( "/com/enonic/xp/app/users/apis/graphql/utils-test.js", "toIntNullReturnsDefault" );
+    }
+}

--- a/src/test/resources/com/enonic/xp/app/users/apis/graphql/utils-test.js
+++ b/src/test/resources/com/enonic/xp/app/users/apis/graphql/utils-test.js
@@ -1,0 +1,14 @@
+var t = require('/lib/xp/testing');
+var utils = require('/apis/graphql/utils');
+
+exports.toIntFromNumber = function () {
+    t.assertEquals(42, utils.toInt(42));
+};
+
+exports.toIntFromString = function () {
+    t.assertEquals(42, utils.toInt('42'));
+};
+
+exports.toIntNullReturnsDefault = function () {
+    t.assertEquals(7, utils.toInt(null, 7));
+};


### PR DESCRIPTION
Fixes #2599

## What

`apis/graphql/utils.js` `toInt` called `.intValue()` on its argument — a `java.lang.Number` method that GraalJS does not expose on JS numbers (Java values are converted to JS primitives on the way in), so the call raised a `TypeError`. Replaced with `Number(number)`, as prescribed in the issue.

The `number == null` branch dereferenced `defaultValue`, which is `undefined` at every call site (all three callers in `apis/graphql/types/objects/connection.js` pass a single argument), so it also threw on Nashorn. It now returns `defaultValue` directly.

## Tests

Added the dual-engine test setup — `testRuntimeOnly 'org.graalvm.polyglot:js'` plus a `testGraalJs` task wired into `check` — and a `ScriptTestSupport` test exercising `toInt` on both engines.

Verified locally against a `publishToMavenLocal` build of enonic/xp#12198 (`8.1.0-SNAPSHOT`):

- `./gradlew :test` — 24/24 green (Nashorn)
- `./gradlew :testGraalJs` — 24/24 green (GraalJS)

## Draft

Kept as a **draft** because it exercises the GraalJS engine via `xpVersion=8.1.0-SNAPSHOT` from `xp.enonicRepo('dev')` — an unreleased platform snapshot — as part of the broader GraalJS-readiness work tracked by enonic/xp#12198. The tests use `ScriptTestSupport`, which does not depend on the `ScriptRunnerSupport` fix from that PR, so the `build` job (which runs `check` → `test` + `testGraalJs`) is currently **green on CI on both engines**, rather than staying red as originally anticipated. Reference: enonic/lib-sql#154.